### PR TITLE
Remove arity of '_'

### DIFF
--- a/apps/xprof_core/src/xprof_core.erl
+++ b/apps/xprof_core/src/xprof_core.erl
@@ -63,9 +63,8 @@
 %% Used to initiate tracing (both by `xprof_core_tracer' and
 %% `xprof_core_trace_handler').
 
--type mfa_id() :: {module(), atom(), arity() | '_'}.
+-type mfa_id() :: {module(), atom(), arity()}.
 %% Used by the GUI and `xprof_core_tracer' to identify mfas.
-%% Arity of `` '_' '' means all arities.
 %% Similar to type `erlang:trace_pattern_mfa()'.
 
 -type mfa_name() :: atom().

--- a/apps/xprof_core/src/xprof_core_lib.erl
+++ b/apps/xprof_core/src/xprof_core_lib.erl
@@ -21,9 +21,6 @@ mfaspec2atom({MFAId, {_MSOff, _MSOn}}) ->
     mfa2atom(MFAId).
 
 -spec mfa2atom(xprof_core:mfa_id()) -> xprof_core:mfa_name().
-mfa2atom({M, F, '_'}) ->
-    list_to_atom(string:join(["xprof_", atom_to_list(M),
-                              atom_to_list(F), "_"], "_"));
 mfa2atom({M,F,A}) ->
     list_to_atom(string:join(["xprof_", atom_to_list(M),
                               atom_to_list(F), integer_to_list(A)], "_")).

--- a/apps/xprof_core/src/xprof_core_records.erl
+++ b/apps/xprof_core/src/xprof_core_records.erl
@@ -116,7 +116,7 @@ get_record_defs(Mod) ->
     case code:get_object_code(Mod) of
         {_Mod, Bin, _Filename} ->
             case beam_lib:chunks(Bin, [abstract_code]) of
-                {ok, {_Mod, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+                {ok, {_, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
                     Defs =
                         [{RecName, {attribute, Anno, record, {RecName, remove_types(Fields)}}}
                          || {attribute, Anno, record, {RecName, Fields}} <- Forms],

--- a/apps/xprof_core/src/xprof_core_trace_handler.erl
+++ b/apps/xprof_core/src/xprof_core_trace_handler.erl
@@ -286,10 +286,6 @@ capture_args_trace_off({MFAId, {MSOff, _MSOn}}) ->
     erlang:trace_pattern(MFAId, MSOff, [local]).
 
 -spec trace_mfa_off(xprof_core:mfa_id()) -> any().
-trace_mfa_off({M, F, '_'}) ->
-    %% FIXME: this will turn off tracing also
-    %% for the same function with a given arity
-    erlang:trace_pattern({M, F, '_'}, false, [local]);
 trace_mfa_off(MFA) ->
     erlang:trace_pattern(MFA, false, [local]).
 

--- a/apps/xprof_core/src/xprof_core_tracer.erl
+++ b/apps/xprof_core/src/xprof_core_tracer.erl
@@ -230,9 +230,8 @@ trace(PidSpec, How, Flags) ->
     end.
 
 -spec send2pids(mfa(), term()) -> any().
-send2pids({M, F, _} = MFA, Msg) ->
+send2pids({_M, _F, _A} = MFA, Msg) ->
     send2pid(MFA, Msg),
-    send2pid({M, F, '_'}, Msg),
     ok.
 
 -spec send2pid(xprof_core:mfa_id(), term()) -> any().

--- a/apps/xprof_gui/src/xprof_gui_rest.erl
+++ b/apps/xprof_gui/src/xprof_gui_rest.erl
@@ -399,10 +399,7 @@ do_handle_req(<<"fav_get_all">>, _Params) ->
 get_mfa(Params) ->
     {binary_to_atom(proplists:get_value(<<"mod">>, Params), latin1),
      binary_to_atom(proplists:get_value(<<"fun">>, Params), latin1),
-     case proplists:get_value(<<"arity">>, Params) of
-         <<"_">> -> '_';
-         Arity -> binary_to_integer(Arity)
-     end}.
+     binary_to_integer(proplists:get_value(<<"arity">>, Params))}.
 
 -spec get_query([{binary(), binary() | true}]) -> binary().
 get_query(Params) ->

--- a/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
+++ b/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
@@ -241,7 +241,7 @@ get_data_for_not_traced_fun(_Config) ->
     ?assertMatch({404, _}, make_get_request("api/data", [
                                              {"mod", "dict"},
                                              {"fun", "new"},
-                                             {"arity", "_"}
+                                             {"arity", "0"}
                                             ])),
     ok.
 


### PR DESCRIPTION
Monitoring any arity is not fully supported (not on the UI) and
problematic (eg demonitoring any-arity also demonitors the same function
with a given arity)